### PR TITLE
Fix/footer/footer  coopyright

### DIFF
--- a/blocks/footer/__columns/footer__columns.css
+++ b/blocks/footer/__columns/footer__columns.css
@@ -1,8 +1,7 @@
 .footer__columns {
   padding: 62px 0 0 0;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: row;  
   grid-column: 3/4;
   grid-row: 2/2;
 }

--- a/blocks/footer/__coopyright-text/_type/footer__coopyright-text_type_wide.css
+++ b/blocks/footer/__coopyright-text/_type/footer__coopyright-text_type_wide.css
@@ -1,3 +1,3 @@
 .footer__coopyright-text_type_wide {
-  max-width: 200px;
+  max-width: 202px;
 }

--- a/blocks/footer/__nav/footer__nav.css
+++ b/blocks/footer/__nav/footer__nav.css
@@ -1,3 +1,10 @@
 .footer__nav {
   
 }
+
+.footer__nav:first-of-type {
+  padding: 0 100px 0 0;
+}
+.footer__nav:last-of-type {
+  padding: 0 0 0 77px;
+}


### PR DESCRIPTION
Изменена ширина footer__copyright-text_type_wide, чтобы слова встали как на макете и изменен отступ между элементами блока footer__columns